### PR TITLE
improve seeds

### DIFF
--- a/app/models/booking.rb
+++ b/app/models/booking.rb
@@ -4,4 +4,6 @@ class Booking < ApplicationRecord
 
   validates :start_time, presence: true, uniqueness: { scope: :mentor }
   validates :status, presence: true
+
+  STATUSES = ["pending", "upcoming", "completed", "canceled"]
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -46,19 +46,22 @@ Mentor::SPECIALTIES.each do |specialty|
 end
 
 puts "creating 3 users for our team"
-[
+team_users = [
   { email: "riyaf3105@gmail.com", name: "Riya Fartyal", photo_url: "https://avatars.githubusercontent.com/u/83643548?v=4" },
   { email: "justin.garcia@gmail.com", name: "Justin Garcia", photo_url: "https://avatars.githubusercontent.com/u/8378384" },
   { email: "fangshuxing0613@gmail.com", name: "Shuxing Fang", photo_url: "https://avatars.githubusercontent.com/u/151457729?v=4" }
-].each do |hash|
+]
+team_users.each do |hash|
   create_user_and_mentor(Mentor::SPECIALTIES.sample, hash[:email], hash[:name], hash[:photo_url])
 end
 
 puts "creating bookings"
 Mentor.all.each do |mentor|
-  random_user = User.all.excluding(mentor.user).sample
-  10.times do
-    Booking.create!(user: random_user, mentor: mentor, start_time: rand(4.weeks).seconds.ago, status: BOOKING::STATUSES.sample)
+  team_users.each do |team_user_hash|
+    team_user = User.where(email: team_user_hash[:email]).first
+    next if team_user == mentor.user
+
+    Booking.create!(user: team_user, mentor: mentor, start_time: rand(4.weeks).seconds.ago, status: Booking::STATUSES.sample)
   end
 end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -22,7 +22,7 @@ def create_user_and_mentor(specialty, input_email = nil, input_name = nil, input
   price = (50..1000).to_a.sample
 
   if input_photo_url.nil?
-    url = "https://this-person-does-not-exist.com/new?gender=all&age=25-50&etnic=all"
+    url = "https://this-person-does-not-exist.com/new?gender=all&age=40&etnic=all"
     json = URI.open(url).string
     src = JSON.parse(json)['src']
     photo_url = "https://this-person-does-not-exist.com#{src}"
@@ -37,7 +37,7 @@ def create_user_and_mentor(specialty, input_email = nil, input_name = nil, input
   puts "finished creating a user and mentor for: #{name}, #{email}"
 end
 
-mentors_per_specialty = 5
+mentors_per_specialty = 8
 puts "creating #{Mentor::SPECIALTIES.count * mentors_per_specialty} fake users"
 Mentor::SPECIALTIES.each do |specialty|
   mentors_per_specialty.times do
@@ -57,7 +57,9 @@ end
 puts "creating bookings"
 Mentor.all.each do |mentor|
   random_user = User.all.excluding(mentor.user).sample
-  Booking.create!(user: random_user, mentor: mentor, start_time: rand(4.weeks).seconds.ago, status: "pending")
+  10.times do
+    Booking.create!(user: random_user, mentor: mentor, start_time: rand(4.weeks).seconds.ago, status: BOOKING::STATUSES.sample)
+  end
 end
 
 puts "done. generated #{User.count} users and #{Mentor.count} mentors and #{Booking.count} bookings"


### PR DESCRIPTION
- use 8 mentors per category, since we’re increasing the number of cards per row
- add 1 booking per mentor per team user, so we have something to look at on the bookings index page